### PR TITLE
feat: propagating change in sequencer uptime feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hai",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Multicollateral debt backed stablecoin",
   "homepage": "https://github.com/hai-on-op/hai#readme",
   "repository": {

--- a/src/contracts/factories/ChainlinkRelayerChild.sol
+++ b/src/contracts/factories/ChainlinkRelayerChild.sol
@@ -2,9 +2,10 @@
 pragma solidity 0.8.20;
 
 import {IChainlinkRelayerChild} from '@interfaces/factories/IChainlinkRelayerChild.sol';
+import {IChainlinkRelayerFactory} from '@interfaces/factories/IChainlinkRelayerFactory.sol';
 import {IChainlinkOracle} from '@interfaces/oracles/IChainlinkOracle.sol';
 
-import {ChainlinkRelayer} from '@contracts/oracles/ChainlinkRelayer.sol';
+import {ChainlinkRelayer, IChainlinkRelayer} from '@contracts/oracles/ChainlinkRelayer.sol';
 
 import {FactoryChild} from '@contracts/factories/FactoryChild.sol';
 
@@ -17,20 +18,30 @@ contract ChainlinkRelayerChild is ChainlinkRelayer, FactoryChild, IChainlinkRela
 
   /**
    * @param  _priceFeed The address of the price feed to relay
-   * @param  _sequencerUptimeFeed The address of the sequencer uptime feed to relay
+   * @param  __sequencerUptimeFeed The address of the sequencer uptime feed to relay
    * @param  _staleThreshold The threshold in seconds to consider the aggregator stale
    */
   constructor(
     address _priceFeed,
-    address _sequencerUptimeFeed,
+    address __sequencerUptimeFeed,
     uint256 _staleThreshold
-  ) ChainlinkRelayer(_priceFeed, _sequencerUptimeFeed, _staleThreshold) {}
+  ) ChainlinkRelayer(_priceFeed, __sequencerUptimeFeed, _staleThreshold) {}
+
+  // --- Overrides ---
+
+  function sequencerUptimeFeed()
+    public
+    view
+    override(ChainlinkRelayer, IChainlinkRelayer)
+    returns (IChainlinkOracle __sequencerUptimeFeed)
+  {
+    return IChainlinkRelayerFactory(factory).sequencerUptimeFeed();
+  }
 
   /**
-   * @dev Overriding method bypasses the null address check, already performed by the factory
+   * @dev    Modifying sequencerUptimeFeed's address results in a no-operation (is read from factory)
+   * @param  __sequencerUptimeFeed Ignored parameter (read from factory)
    * @inheritdoc ChainlinkRelayer
    */
-  function _setSequencerUptimeFeed(address _sequencerUptimeFeed) internal override {
-    sequencerUptimeFeed = IChainlinkOracle(_sequencerUptimeFeed);
-  }
+  function _setSequencerUptimeFeed(address __sequencerUptimeFeed) internal override {}
 }

--- a/src/contracts/factories/ChainlinkRelayerFactory.sol
+++ b/src/contracts/factories/ChainlinkRelayerFactory.sol
@@ -45,7 +45,11 @@ contract ChainlinkRelayerFactory is Authorizable, IChainlinkRelayerFactory {
     address _priceFeed,
     uint256 _staleThreshold
   ) external isAuthorized returns (IBaseOracle _chainlinkRelayer) {
-    _chainlinkRelayer = new ChainlinkRelayerChild(_priceFeed, address(sequencerUptimeFeed), _staleThreshold);
+    _chainlinkRelayer = new ChainlinkRelayerChild({
+      _priceFeed: _priceFeed,
+      __sequencerUptimeFeed: address(0), // read from factory
+      _staleThreshold: _staleThreshold
+    });
     _chainlinkRelayers.add(address(_chainlinkRelayer));
     emit NewChainlinkRelayer(address(_chainlinkRelayer), _priceFeed, address(sequencerUptimeFeed), _staleThreshold);
   }

--- a/test/unit/oracles/ChainlinkRelayerFactory.t.sol
+++ b/test/unit/oracles/ChainlinkRelayerFactory.t.sol
@@ -177,4 +177,15 @@ contract Unit_ChainlinkRelayerFactory_SetSequencerUptimeFeed is Base {
 
     assertEq(address(chainlinkRelayerFactory.sequencerUptimeFeed()), _sequencerUptimeFeed);
   }
+
+  function test_Propagate_SequencerUptimeFeed(address _sequencerUptimeFeed) public happyPath(_sequencerUptimeFeed) {
+    _mockDecimals(18);
+    _mockDescription('ChainlinkPriceFeed');
+
+    chainlinkRelayerFactory.deployChainlinkRelayer(address(mockPriceFeed), 1);
+
+    chainlinkRelayerFactory.setSequencerUptimeFeed(_sequencerUptimeFeed);
+
+    assertEq(address(chainlinkRelayerChild.sequencerUptimeFeed()), _sequencerUptimeFeed);
+  }
 }


### PR DESCRIPTION
using CAHChild mechanics, the current PR aims to propagate the change in `sequencerUptimeFeed` on the factory.
on previous setup, if the feed is changed, governance needs to:
- change it on the factory
- deploy a new relayer
- setup the new relayer as oracle

on current setup:
- change it on the factory

🥕